### PR TITLE
Test: Retry and Sleep if PDFReactor Server is unreachable

### DIFF
--- a/tests/testdata/test.php
+++ b/tests/testdata/test.php
@@ -4,6 +4,7 @@ require_once('lib/PDFreactor.class.php');
 
 use com\realobjects\pdfreactor\webservice\client\PDFreactor as PDFreactor;
 use com\realobjects\pdfreactor\webservice\client\LogLevel as LogLevel;
+use com\realobjects\pdfreactor\webservice\client\UnreachableServiceException;
 use com\realobjects\pdfreactor\webservice\client\ViewerPreferences as ViewerPreferences;
 
 $content = file_get_contents('resources/content.html');
@@ -36,7 +37,15 @@ $config = [
     ],
 ];
 
-$result = $pdfReactor->convertAsBinary($config);
+for ($i = 0; $i < 5; $i++) {
+    try {
+        $result = $pdfReactor->convertAsBinary($config);
+        break;
+    } catch (UnreachableServiceException $e) {
+        echo 'PDF Reactor Server unreachable. Retry in 10 seconds.' . "\n";
+        sleep(10);
+    }
+}
 
 if (preg_match('/^%PDF-/', $result)) {
     echo 'PDF generation was successful' . "\n";


### PR DESCRIPTION
The tests still are unsuccessful sometimes. I think the PDFReactor needs some time to be ready. I add a try/catch and give it 5 retries.