### PR TITLE
[tests only] Only run keepalive on stable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,3 +76,4 @@ jobs:
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days
     - uses: gautamkrishnar/keepalive-workflow@v1
+      if: matrix.ddev_version == 'stable'


### PR DESCRIPTION
## The Issue

Tests failed (https://github.com/ddev/ddev-pdfreactor/actions/runs/5264200451) due to keepalive running two places; just run it in one.

