### PR TITLE
bump github-action-add-on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ on:
         required: false
         default: false
 
-# This is required for "gautamkrishnar/keepalive-workflow"
+# Required permissions for keep-alive, used by ddev/github-action-add-on-test
 permissions:
-  contents: write
+  actions: write
 
 jobs:
   tests:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ddev/github-action-add-on-test@v1
+      - uses: ddev/github-action-add-on-test@v2
         with:
           ddev_version: ${{ matrix.ddev_version }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker-compose.pdfreactor.yaml
+++ b/docker-compose.pdfreactor.yaml
@@ -9,6 +9,7 @@ services:
       com.ddev.approot: $DDEV_APPROOT
     volumes:
     - ".:/mnt/ddev_config"
+    - "ddev-global-cache:/mnt/ddev-global-cache"
     - "./pdfreactor:/ro/config"
     external_links:
     - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"


### PR DESCRIPTION
This PR bumps github-action-add-on to v2.
This prevents the dummy commits created by the keep-alive action.

See https://github.com/ddev/github-action-add-on-test/releases/tag/v2.0.0

And adds volume from:
- https://github.com/ddev/ddev-addon-template/pull/45